### PR TITLE
feat: build interactive CSS dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,973 +1,201 @@
 <!DOCTYPE html>
 <html lang="de">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>CSS Didaktik Dashboard – Konzept</title>
-  <style>
-    :root {
-      color-scheme: light dark;
-      --bg: #f7f7fb;
-      --fg: #12121b;
-      --accent: #5b6dff;
-      --border: #d1d6e5;
-      --badge-bg: #eef1ff;
-      --pro-bg: #ffeacc;
-      --pro-fg: #a15b00;
-      font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      line-height: 1.6;
-    }
-
-    body {
-      margin: 0;
-      padding: 0;
-      background: var(--bg);
-      color: var(--fg);
-    }
-
-    header {
-      background: white;
-      border-bottom: 1px solid var(--border);
-      padding: 2rem clamp(1rem, 3vw, 4rem);
-      position: sticky;
-      top: 0;
-      z-index: 10;
-      backdrop-filter: blur(12px);
-    }
-
-    header h1 {
-      margin: 0 0 0.5rem;
-      font-size: clamp(1.8rem, 3vw, 2.8rem);
-    }
-
-    header p {
-      margin: 0;
-      max-width: 72ch;
-      color: #4a4f63;
-    }
-
-    main {
-      padding: 2rem clamp(1rem, 3vw, 4rem) 5rem;
-      display: grid;
-      gap: 2.5rem;
-    }
-
-    section {
-      background: white;
-      border: 1px solid var(--border);
-      border-radius: 16px;
-      padding: clamp(1.5rem, 2.5vw, 2.75rem);
-      box-shadow: 0 12px 32px rgba(26, 30, 55, 0.08);
-    }
-
-    section h2 {
-      margin-top: 0;
-      font-size: 1.6rem;
-      border-bottom: 2px solid var(--border);
-      padding-bottom: 0.75rem;
-    }
-
-    h3 {
-      margin-top: 2rem;
-      font-size: 1.2rem;
-    }
-
-    h4 {
-      margin-top: 1.5rem;
-      font-size: 1.05rem;
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
-      color: #585f77;
-    }
-
-    ul, ol {
-      margin: 0.75rem 0 0.75rem 1.5rem;
-    }
-
-    li {
-      margin-bottom: 0.35rem;
-    }
-
-    .grid {
-      display: grid;
-      gap: 1.5rem;
-    }
-
-    .grid.cols-2 {
-      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-    }
-
-    .grid.cols-3 {
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    }
-
-    .badge {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.35rem;
-      padding: 0.1rem 0.55rem;
-      border-radius: 999px;
-      font-size: 0.75rem;
-      background: var(--badge-bg);
-      color: var(--accent);
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      margin-left: 0.5rem;
-    }
-
-    .badge.pro {
-      background: var(--pro-bg);
-      color: var(--pro-fg);
-    }
-
-    pre {
-      background: #0e172a;
-      color: #f5f7ff;
-      padding: 1rem 1.25rem;
-      border-radius: 12px;
-      overflow-x: auto;
-      font-size: 0.95rem;
-      line-height: 1.45;
-    }
-
-    code {
-      background: rgba(91, 109, 255, 0.1);
-      border-radius: 6px;
-      padding: 0.15rem 0.35rem;
-      font-size: 0.95rem;
-    }
-
-    table {
-      width: 100%;
-      border-collapse: collapse;
-      margin-top: 1rem;
-    }
-
-    th, td {
-      border: 1px solid var(--border);
-      padding: 0.65rem 0.75rem;
-      text-align: left;
-      vertical-align: top;
-    }
-
-    th {
-      background: #f4f6ff;
-    }
-
-    details {
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      padding: 0.85rem 1rem;
-      margin-top: 1rem;
-      background: #fafbff;
-    }
-
-    details summary {
-      cursor: pointer;
-      font-weight: 600;
-    }
-
-    .flex {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 1.5rem;
-    }
-
-    .flex > div {
-      flex: 1 1 320px;
-    }
-
-    .callout {
-      background: rgba(91, 109, 255, 0.08);
-      border-left: 4px solid var(--accent);
-      padding: 1rem 1.25rem;
-      border-radius: 8px;
-      margin-top: 1.25rem;
-    }
-
-    .checklist li {
-      margin-bottom: 0.6rem;
-    }
-
-    @media (max-width: 720px) {
-      header {
-        position: static;
-      }
-    }
-  </style>
-</head>
-<body>
-  <header>
-    <h1>Interaktives CSS-Dashboard – UX/Frontend-Konzept</h1>
-    <p>
-      Ziel: Ein Single-File-fähiges Lern- &amp; Experimentier-Dashboard, das CSS-Eigenschaften
-      und Direktiven für Anfänger bis Fortgeschrittene didaktisch aufbereitet und in Echtzeit visualisiert.
-    </p>
-  </header>
-  <main>
-    <section id="zielgruppe">
-      <h2>1. Zielgruppe &amp; Lernziele</h2>
-      <div class="grid cols-2">
-        <div>
-          <h3>Zielgruppe</h3>
-          <ul>
-            <li>Studierende &amp; Quereinsteiger:innen, die CSS-Grundlagen lernen möchten.</li>
-            <li>Junior-Frontend-Entwickler:innen, die ihr CSS-Mentalmodell schärfen wollen.</li>
-            <li>Fortgeschrittene Professionals, die seltene Properties testen &amp; dokumentieren.</li>
-          </ul>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CSS Didaktik Dashboard</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="app-shell">
+      <aside class="sidebar">
+        <div class="brand">
+          <h1 class="brand__title">CSS Didaktik</h1>
+          <p class="brand__subtitle">Experimentiere, lerne und veröffentliche Stilvarianten.</p>
         </div>
-        <div>
-          <h3>Lernziele</h3>
-          <ul>
-            <li>Wirkung &amp; Zusammenspiel gängiger CSS-Properties verstehen.</li>
-            <li>Kaskade, Vererbung, Spezifität &amp; Quellreihenfolge anhand interaktiver Beispiele begreifen.</li>
-            <li>Best Practices durch sofort kopierbare Snippets anwenden.</li>
-            <li>Fehlerquellen identifizieren &amp; Alternativen finden (z. B. fehlende Voraussetzungen).</li>
-          </ul>
+        <nav class="nav" aria-label="Primäre Navigation">
+          <div class="nav__section">
+            <h3>Workspace</h3>
+            <ul class="nav__links">
+              <li><a href="#controls">Eigenschaften</a></li>
+              <li><a href="#preview">Sandbox</a></li>
+              <li><a href="#inspector">Inspector</a></li>
+              <li><a href="#export">Code Export</a></li>
+            </ul>
+          </div>
+          <div class="nav__section">
+            <h3>Ressourcen</h3>
+            <ul class="nav__links">
+              <li><a href="#">Guides</a></li>
+              <li><a href="#">Playground</a></li>
+              <li><a href="#">Community</a></li>
+            </ul>
+          </div>
+        </nav>
+      </aside>
+      <main class="workspace">
+        <header class="toolbar" aria-label="Steuerleiste">
+          <div class="toolbar__group">
+            <label for="preset-select">Preset</label>
+            <select id="preset-select" aria-label="Preset auswählen"></select>
+          </div>
+          <div class="toolbar__group">
+            <button type="button" id="undo-button" aria-label="Zurück">↺ Undo</button>
+            <button type="button" id="redo-button" aria-label="Wiederholen">↻ Redo</button>
+            <button type="button" id="reset-button" aria-label="Auf Ausgangszustand zurücksetzen">Reset</button>
+          </div>
+        </header>
+        <div class="workspace-columns">
+          <section class="panel" id="controls" aria-labelledby="controls-heading">
+            <h2 id="controls-heading">Eigenschaften</h2>
+            <form data-controls>
+              <fieldset>
+                <legend>Layout</legend>
+                <div class="form-control">
+                  <label for="display-select">Display</label>
+                  <select id="display-select" data-property="display">
+                    <option value="block">Block</option>
+                    <option value="flex">Flex</option>
+                    <option value="grid">Grid</option>
+                  </select>
+                </div>
+                <div class="form-control">
+                  <label for="direction-select">Flex-Richtung</label>
+                  <select id="direction-select" data-property="flex-direction">
+                    <option value="row">Zeile</option>
+                    <option value="row-reverse">Zeile (invertiert)</option>
+                    <option value="column">Spalte</option>
+                    <option value="column-reverse">Spalte (invertiert)</option>
+                  </select>
+                </div>
+                <div class="form-control">
+                  <label for="justify-select">Ausrichtung Hauptachse</label>
+                  <select id="justify-select" data-property="justify-content">
+                    <option value="flex-start">Flex-Start</option>
+                    <option value="center">Zentriert</option>
+                    <option value="space-between">Space Between</option>
+                    <option value="space-around">Space Around</option>
+                    <option value="space-evenly">Space Evenly</option>
+                    <option value="flex-end">Flex-Ende</option>
+                  </select>
+                </div>
+                <div class="form-control">
+                  <label for="align-select">Ausrichtung Querachse</label>
+                  <select id="align-select" data-property="align-items">
+                    <option value="stretch">Stretch</option>
+                    <option value="flex-start">Flex-Start</option>
+                    <option value="center">Zentriert</option>
+                    <option value="flex-end">Flex-Ende</option>
+                  </select>
+                </div>
+                <div class="form-control">
+                  <label for="gap-range">Gap <span data-output-for="gap-range"></span></label>
+                  <input id="gap-range" type="range" min="0" max="4" step="0.25" data-property="gap" data-unit="rem" />
+                </div>
+                <div class="form-control">
+                  <label for="padding-range">Innenabstand <span data-output-for="padding-range"></span></label>
+                  <input id="padding-range" type="range" min="0" max="4" step="0.25" data-property="padding" data-unit="rem" />
+                </div>
+                <div class="form-control">
+                  <label for="grid-columns">Grid-Spalten</label>
+                  <input id="grid-columns" type="text" placeholder="repeat(3, 1fr)" data-property="grid-template-columns" />
+                </div>
+                <div class="toggle">
+                  <input id="shadow-toggle" type="checkbox" data-property="box-shadow" data-on="0 24px 48px rgba(15, 23, 42, 0.16)" data-off="none" />
+                  <label for="shadow-toggle">Box-Shadow aktivieren</label>
+                </div>
+              </fieldset>
+              <fieldset>
+                <legend>Typografie</legend>
+                <div class="form-control">
+                  <label for="font-size-range">Fontgröße <span data-output-for="font-size-range"></span></label>
+                  <input id="font-size-range" type="range" min="0.8" max="2" step="0.05" data-property="font-size" data-unit="rem" />
+                </div>
+                <div class="form-control">
+                  <label for="font-weight-select">Schriftstärke</label>
+                  <select id="font-weight-select" data-property="font-weight">
+                    <option value="300">Light</option>
+                    <option value="400">Normal</option>
+                    <option value="500">Medium</option>
+                    <option value="600">Semibold</option>
+                    <option value="700">Bold</option>
+                  </select>
+                </div>
+                <div class="form-control">
+                  <label for="line-height-range">Zeilenhöhe <span data-output-for="line-height-range"></span></label>
+                  <input id="line-height-range" type="range" min="1" max="2" step="0.05" data-property="line-height" />
+                </div>
+              </fieldset>
+              <fieldset>
+                <legend>Farben &amp; Rahmen</legend>
+                <div class="form-control">
+                  <label for="background-color">Hintergrund</label>
+                  <input id="background-color" type="color" data-property="background-color" />
+                </div>
+                <div class="form-control">
+                  <label for="text-color">Textfarbe</label>
+                  <input id="text-color" type="color" data-property="color" />
+                </div>
+                <div class="form-control">
+                  <label for="radius-range">Radius <span data-output-for="radius-range"></span></label>
+                  <input id="radius-range" type="range" min="0" max="3" step="0.25" data-property="border-radius" data-unit="rem" />
+                </div>
+                <div class="form-control">
+                  <label for="border-width">Border</label>
+                  <input id="border-width" type="range" min="0" max="6" step="1" data-property="border-width" data-unit="px" />
+                </div>
+                <div class="form-control">
+                  <label for="border-color">Border-Farbe</label>
+                  <input id="border-color" type="color" data-property="border-color" />
+                </div>
+              </fieldset>
+            </form>
+          </section>
+          <section class="panel" id="preview" aria-labelledby="preview-heading">
+            <h2 id="preview-heading">Sandbox</h2>
+            <div class="preview-surface preview-sandbox">
+              <iframe class="preview-frame" id="preview-frame" title="CSS Vorschau"></iframe>
+            </div>
+          </section>
+          <section class="panel" id="inspector" aria-labelledby="inspector-heading">
+            <h2 id="inspector-heading">Inspector &amp; Code</h2>
+            <div>
+              <h3>Aktive Regeln</h3>
+              <ul class="rules-list" data-rule-list></ul>
+            </div>
+            <div>
+              <h3>Before / After</h3>
+              <table class="diff-table" aria-live="polite">
+                <thead>
+                  <tr>
+                    <th>Eigenschaft</th>
+                    <th>Vorher</th>
+                    <th>Nachher</th>
+                  </tr>
+                </thead>
+                <tbody data-diff-body></tbody>
+              </table>
+            </div>
+            <div>
+              <h3>Warnungen</h3>
+              <ul class="warning-list" data-warning-list></ul>
+            </div>
+            <div id="export" aria-labelledby="export-heading">
+              <h3 id="export-heading">Code Export</h3>
+              <div class="form-control">
+                <label for="export-mode">Export Format</label>
+                <select id="export-mode">
+                  <option value="inline">Inline Styles</option>
+                  <option value="scoped">Scoped Styles</option>
+                  <option value="global">Global Styles</option>
+                </select>
+              </div>
+              <pre class="code-output"><code data-code-output class="code-output__placeholder">Änderungen vornehmen, um Code zu erzeugen…</code></pre>
+            </div>
+          </section>
         </div>
-      </div>
-    </section>
-
-    <section id="coverage">
-      <h2>2. Coverage – Kategorien &amp; Properties</h2>
-      <p>
-        Jede Kategorie enthält 10–30 repräsentative Properties plus 1–2 Direktiven. Optionale/fortgeschrittene Themen
-        sind mit einem <span class="badge pro">Pro</span>-Badge markiert.
-      </p>
-      <div class="grid cols-2">
-        <div>
-          <h3>Layout</h3>
-          <ul>
-            <li>display</li>
-            <li>position</li>
-            <li>top / right / bottom / left</li>
-            <li>inset</li>
-            <li>z-index</li>
-            <li>float</li>
-            <li>clear</li>
-            <li>overflow / overflow-x / overflow-y</li>
-            <li>visibility</li>
-            <li>contain <span class="badge pro">Pro</span></li>
-            <li>@page <span class="badge pro">Pro</span></li>
-          </ul>
-        </div>
-        <div>
-          <h3>Box Model</h3>
-          <ul>
-            <li>width / min-width / max-width</li>
-            <li>height / min-height / max-height</li>
-            <li>box-sizing</li>
-            <li>margin (+-top/right/bottom/left)</li>
-            <li>padding (+-top/right/bottom/left)</li>
-            <li>border (style/width/color)</li>
-            <li>outline</li>
-            <li>border-image <span class="badge pro">Pro</span></li>
-            <li>aspect-ratio</li>
-            <li>object-fit</li>
-            <li>@property <span class="badge pro">Pro</span></li>
-          </ul>
-        </div>
-        <div>
-          <h3>Flexbox</h3>
-          <ul>
-            <li>display: flex / inline-flex</li>
-            <li>flex-direction</li>
-            <li>flex-wrap</li>
-            <li>justify-content</li>
-            <li>align-items</li>
-            <li>align-content</li>
-            <li>gap / row-gap / column-gap</li>
-            <li>flex</li>
-            <li>flex-grow</li>
-            <li>flex-shrink</li>
-            <li>flex-basis</li>
-            <li>order</li>
-            <li>place-content</li>
-          </ul>
-        </div>
-        <div>
-          <h3>Grid</h3>
-          <ul>
-            <li>display: grid / inline-grid</li>
-            <li>grid-template-rows</li>
-            <li>grid-template-columns</li>
-            <li>grid-template-areas</li>
-            <li>grid-auto-rows / grid-auto-columns</li>
-            <li>grid-auto-flow</li>
-            <li>grid-column / grid-row</li>
-            <li>justify-items / align-items</li>
-            <li>justify-content / align-content</li>
-            <li>place-items / place-content</li>
-            <li>gap / row-gap / column-gap</li>
-            <li>minmax()</li>
-            <li>repeat()</li>
-            <li>subgrid <span class="badge pro">Pro</span></li>
-            <li>@supports</li>
-          </ul>
-        </div>
-        <div>
-          <h3>Typografie</h3>
-          <ul>
-            <li>font-family</li>
-            <li>font-size (px / rem / clamp())</li>
-            <li>line-height</li>
-            <li>font-weight</li>
-            <li>font-style</li>
-            <li>font-variant <span class="badge pro">Pro</span></li>
-            <li>letter-spacing</li>
-            <li>word-spacing</li>
-            <li>text-align</li>
-            <li>text-transform</li>
-            <li>text-decoration</li>
-            <li>text-shadow</li>
-            <li>white-space</li>
-            <li>@font-face</li>
-            <li>font-display</li>
-          </ul>
-        </div>
-        <div>
-          <h3>Farbe &amp; Hintergrund</h3>
-          <ul>
-            <li>color</li>
-            <li>background-color</li>
-            <li>background-image</li>
-            <li>background-size</li>
-            <li>background-position</li>
-            <li>background-repeat</li>
-            <li>background-attachment</li>
-            <li>background-clip</li>
-            <li>background-origin</li>
-            <li>linear-gradient()</li>
-            <li>radial-gradient()</li>
-            <li>conic-gradient() <span class="badge pro">Pro</span></li>
-            <li>multiple backgrounds</li>
-            <li>mask-image <span class="badge pro">Pro</span></li>
-            <li>@color-profile <span class="badge pro">Pro</span></li>
-          </ul>
-        </div>
-        <div>
-          <h3>Dekoration &amp; Effekte</h3>
-          <ul>
-            <li>border-radius</li>
-            <li>border-style</li>
-            <li>box-shadow</li>
-            <li>text-shadow</li>
-            <li>filter</li>
-            <li>backdrop-filter <span class="badge pro">Pro</span></li>
-            <li>mix-blend-mode <span class="badge pro">Pro</span></li>
-            <li>opacity</li>
-            <li>outline-offset</li>
-            <li>clip-path <span class="badge pro">Pro</span></li>
-            <li>mask-mode <span class="badge pro">Pro</span></li>
-            <li>cursor</li>
-          </ul>
-        </div>
-        <div>
-          <h3>Transform, Transition &amp; Animation</h3>
-          <ul>
-            <li>transform</li>
-            <li>transform-origin</li>
-            <li>transform-style <span class="badge pro">Pro</span></li>
-            <li>perspective</li>
-            <li>transition-property</li>
-            <li>transition-duration</li>
-            <li>transition-timing-function</li>
-            <li>transition-delay</li>
-            <li>@keyframes</li>
-            <li>animation-name</li>
-            <li>animation-duration</li>
-            <li>animation-iteration-count</li>
-            <li>animation-direction</li>
-            <li>animation-play-state</li>
-            <li>animation-fill-mode</li>
-            <li>scroll-timeline <span class="badge pro">Pro</span></li>
-          </ul>
-        </div>
-        <div>
-          <h3>Listen &amp; Tabellen</h3>
-          <ul>
-            <li>list-style-type</li>
-            <li>list-style-position</li>
-            <li>list-style-image</li>
-            <li>counter-reset <span class="badge pro">Pro</span></li>
-            <li>counter-increment <span class="badge pro">Pro</span></li>
-            <li>table-layout</li>
-            <li>border-collapse</li>
-            <li>border-spacing</li>
-            <li>caption-side</li>
-            <li>empty-cells</li>
-            <li>vertical-align</li>
-            <li>::marker</li>
-            <li>::selection <span class="badge pro">Pro</span></li>
-          </ul>
-        </div>
-        <div>
-          <h3>Selektoren &amp; Pseudoklassen</h3>
-          <ul>
-            <li>.class</li>
-            <li>#id</li>
-            <li>[attribute]</li>
-            <li>:hover</li>
-            <li>:focus</li>
-            <li>:active</li>
-            <li>:disabled</li>
-            <li>:is()</li>
-            <li>:has() <span class="badge pro">Pro</span></li>
-            <li>:where() <span class="badge pro">Pro</span></li>
-            <li>::before</li>
-            <li>::after</li>
-            <li>::marker</li>
-            <li>::selection <span class="badge pro">Pro</span></li>
-            <li>:nth-child()</li>
-            <li>:not()</li>
-          </ul>
-        </div>
-        <div>
-          <h3>Responsive &amp; Logik</h3>
-          <ul>
-            <li>@media (width)</li>
-            <li>@media (prefers-color-scheme)</li>
-            <li>@media (prefers-reduced-motion)</li>
-            <li>@supports</li>
-            <li>container-type</li>
-            <li>container-name</li>
-            <li>@container</li>
-            <li>clamp()</li>
-            <li>min()</li>
-            <li>max()</li>
-            <li>env()</li>
-            <li>prefers-contrast <span class="badge pro">Pro</span></li>
-            <li>size-adjust <span class="badge pro">Pro</span></li>
-          </ul>
-        </div>
-        <div>
-          <h3>Variablen &amp; Funktionen</h3>
-          <ul>
-            <li>--custom-property</li>
-            <li>var()</li>
-            <li>calc()</li>
-            <li>clamp()</li>
-            <li>min()</li>
-            <li>max()</li>
-            <li>env()</li>
-            <li>@property <span class="badge pro">Pro</span></li>
-            <li>color-mix() <span class="badge pro">Pro</span></li>
-            <li>toggle() <span class="badge pro">Pro</span></li>
-          </ul>
-        </div>
-        <div>
-          <h3>Kaskade &amp; Layer</h3>
-          <ul>
-            <li>:root</li>
-            <li>inherit</li>
-            <li>initial</li>
-            <li>unset</li>
-            <li>revert</li>
-            <li>@layer <span class="badge pro">Pro</span></li>
-            <li>@import</li>
-            <li>cascade-layer order <span class="badge pro">Pro</span></li>
-            <li>specificity calculation</li>
-            <li>important!</li>
-          </ul>
-        </div>
-      </div>
-    </section>
-
-    <section id="information-architecture">
-      <h2>3. Informationsarchitektur &amp; Navigation</h2>
-      <div class="grid cols-2">
-        <div>
-          <h3>Linke Seitenleiste</h3>
-          <ul>
-            <li>Kategorienbaum (Accordion) mit Suchfeld.</li>
-            <li>Filterchips: „Nur Basics“, „Alles“, „Nur Pro“.</li>
-            <li>Suchalgorithmen: Fuzzy Match, Kategorie-Gewichtung.</li>
-            <li>Favoritenbereich (per Drag &amp; Drop in Seitenleiste anheftbar).</li>
-          </ul>
-        </div>
-        <div>
-          <h3>Hauptbereich (Desktop)</h3>
-          <p>3 Spalten, responsiv auf 1–2 Spalten:</p>
-          <ol>
-            <li><strong>Property-Panel</strong>: dynamische Controls inkl. Docs.</li>
-            <li><strong>Code-Panel</strong>: generiertes CSS mit Copy-CTA.</li>
-            <li><strong>Live-Vorschau</strong>: Sandbox mit Tabs.</li>
-          </ol>
-        </div>
-      </div>
-      <h3>Toolbar (Top)</h3>
-      <ul>
-        <li>Buttons: Reset, Undo, Redo, Dark/Light Toggle.</li>
-        <li>Toggle: „Nur geänderte Eigenschaften“.</li>
-        <li>Preset-Dropdown (Flex-Center etc.).</li>
-        <li>Export-Menü: HTML/CSS herunterladen.</li>
-      </ul>
-    </section>
-
-    <section id="wireframes">
-      <h2>4. Sitemap &amp; Wireframes</h2>
-      <div class="grid cols-2">
-        <div>
-          <h3>Sitemap</h3>
-          <ul>
-            <li>Dashboard
-              <ul>
-                <li>Start (Intro &amp; Quick Presets)</li>
-                <li>Kategorien (Sidebar Navigation)
-                  <ul>
-                    <li>Layout</li>
-                    <li>Box Model</li>
-                    <li>Flexbox</li>
-                    <li>…</li>
-                  </ul>
-                </li>
-                <li>Presets &amp; Vorlagen</li>
-                <li>Lernressourcen (Glossar, Cheatsheets)</li>
-                <li>Einstellungen (Sprache, Reset, Datenexport)</li>
-              </ul>
-            </li>
-          </ul>
-        </div>
-        <div>
-          <h3>Wireframe Desktop (3 Spalten)</h3>
-          <pre>
-┌─────────────────────────────────────────────────────────┐
-│ Toolbar: Reset | Undo/Redo | Mode | Presets | Export    │
-├───────────────┬─────────────────┬───────────────────────┤
-│ Sidebar        │ Property-Panel  │ Live-Vorschau        │
-│ - Suche        │ - Tabs: Basics  │ - Tabs: Text/Card... │
-│ - Kategorien   │ - Controls      │ - Split View Toggle  │
-│ - Filterchips  │ - Hinweise      │ - Inspector Overlay  │
-│                │                 │                       │
-├───────────────┴─────────────────┤ Code-Panel (Bottom)   │
-│ Responsive: Code-Panel klappt als Drawer aus            │
-└─────────────────────────────────────────────────────────┘
-          </pre>
-        </div>
-      </div>
-      <div class="grid cols-2">
-        <div>
-          <h3>Wireframe Tablet (2 Spalten)</h3>
-          <pre>
-┌──────────────────────────────────────┐
-│ Toolbar                              │
-├───────────────┬──────────────────────┤
-│ Sidebar       │ Property-Panel       │
-├───────────────┴──────────────────────┤
-│ Live-Vorschau (Tabs)                 │
-├──────────────────────────────────────┤
-│ Code-Panel (Collapsible)             │
-└──────────────────────────────────────┘
-          </pre>
-        </div>
-        <div>
-          <h3>Wireframe Mobile (Stack)</h3>
-          <pre>
-┌───────────────────────────────┐
-│ Toolbar (Hamburger für Menü)  │
-├───────────────────────────────┤
-│ Sidebar als Overlay           │
-├───────────────────────────────┤
-│ Property-Panel Accordion      │
-├───────────────────────────────┤
-│ Live-Vorschau (Swipe Tabs)    │
-├───────────────────────────────┤
-│ Code-Panel Toggle             │
-└───────────────────────────────┘
-          </pre>
-        </div>
-      </div>
-    </section>
-
-    <section id="preview-didactics">
-      <h2>5. Live-Vorschau &amp; Didaktik</h2>
-      <div class="grid cols-2">
-        <div>
-          <h3>Sandbox-DOM</h3>
-          <ul>
-            <li>Tabs: Text, Card, Grid, Form, Table, Hero, Artikel.</li>
-            <li>Jede Komponente mit semantischem HTML &amp; ARIA.</li>
-            <li>Before/After-Slider für Vorher/Nachher.</li>
-            <li>Overlay zeigt geänderte Nodes, Tooltips mit computed styles.</li>
-          </ul>
-        </div>
-        <div>
-          <h3>Didaktische Features</h3>
-          <ul>
-            <li>Konflikt-Hinweise (z. B. Hinweis bei fehlendem Flex-Container).</li>
-            <li>Specificity-Inspector mit Visualisierung der Layer &amp; Prioritäten.</li>
-            <li>Merksätze &amp; Mini-Übungen in Sidebar (z. B. „Positioniere das Badge…“).</li>
-            <li>Copyable Snippets mit Option „Nur geänderte Regeln“.</li>
-          </ul>
-        </div>
-      </div>
-    </section>
-
-    <section id="interaktionen">
-      <h2>6. Interaktion &amp; UX-Details</h2>
-      <div class="grid cols-2">
-        <div>
-          <h3>Direkte Manipulation</h3>
-          <ul>
-            <li>Drag-Handles in Vorschau für Margin/Padding (Snapping 4px / 0.25rem).</li>
-            <li>Farbrad + eyedropper (wenn verfügbar).</li>
-            <li>Einheiten-Dropdown (px, rem, %, vw/vh, fr, deg).</li>
-            <li>Slider mit konfigurierbaren Steps &amp; Constraints.</li>
-          </ul>
-        </div>
-        <div>
-          <h3>Produktivität</h3>
-          <ul>
-            <li>Undo/Redo (Ctrl/Cmd+Z/Y).</li>
-            <li>Code kopieren (Ctrl/Cmd+C).</li>
-            <li>Kurzhilfe (F1) mit Tastenkürzel-Overlay.</li>
-            <li>Suche (/) fokussiert Sidebar-Input.</li>
-            <li>LocalStorage: Session-Persistenz, Custom Presets.</li>
-          </ul>
-        </div>
-      </div>
-      <div class="callout">
-        <strong>Snapping &amp; Constraints:</strong> Validierung im PropertyModel verhindert unsinnige Werte,
-        UIControls bieten Quick-Buttons für Standardwerte (0, auto, 100%).
-      </div>
-    </section>
-
-    <section id="technik">
-      <h2>7. Technische Leitplanken</h2>
-      <div class="grid cols-2">
-        <div>
-          <h3>Architektur (Modules)</h3>
-          <ul>
-            <li><strong>PropertyModel</strong>: JSON-Definitionen, Validierung, Abhängigkeiten.</li>
-            <li><strong>StateStore</strong>: zentraler Zustand, History, Undo/Redo-Stack.</li>
-            <li><strong>UIControls</strong>: Rendert Controls aus Schema, Event-Bindings.</li>
-            <li><strong>CodeGen</strong>: Generiert CSS (Inline, Scoped, Global) + Formatierung.</li>
-            <li><strong>PreviewSandbox</strong>: Shadow DOM oder iFrame, Synchronisation, Overlays.</li>
-            <li><strong>Inspector</strong>: computed styles, Specificity-Berechnung, Konflikt-Hinweise.</li>
-          </ul>
-        </div>
-        <div>
-          <h3>Technik &amp; Performance</h3>
-          <ul>
-            <li>Reines HTML/CSS/JS (ES6 Modules), keine Bundler.</li>
-            <li>Batch-DOM-Updates via <code>requestAnimationFrame</code>.</li>
-            <li>Eingaben mit Debounce, differenzielle Updates.</li>
-            <li>i18n: Texte in JSON (de/en), UI reagiert live auf Sprachwechsel.</li>
-            <li>A11y: ARIA-Labels, Fokus-Traps, High-Contrast-Mode, Respekt vor <code>prefers-reduced-motion</code>.</li>
-          </ul>
-        </div>
-      </div>
-    </section>
-
-    <section id="data-model">
-      <h2>8. Datenmodell &amp; Beispiele</h2>
-      <p>Beispiel-Schema für drei Kategorien (Typografie, Flexbox, Grid). JSON kann direkt im PropertyModel verwendet werden.</p>
-      <pre>
-{
-  "typography": [
-    {
-      "name": "font-size",
-      "type": "length",
-      "units": ["px", "rem", "em", "%"],
-      "range": { "min": 10, "max": 72, "step": 1 },
-      "default": "16px",
-      "examples": ["16px", "1rem", "clamp(1rem, 2vw + .5rem, 1.5rem)"],
-      "doc": "Basisschriftgröße; beeinflusst Em-basierte Maße.",
-      "requires": [],
-      "shorthandOf": null,
-      "longhands": [],
-      "conflictsWith": [],
-      "category": "Typografie"
-    }
-  ],
-  "flexbox": [
-    {
-      "name": "justify-content",
-      "type": "enum",
-      "values": ["flex-start", "center", "space-between", "space-around", "space-evenly"],
-      "default": "flex-start",
-      "requires": [{ "property": "display", "value": "flex" }],
-      "doc": "Steuert horizontale Ausrichtung im Hauptachsen-Kontext.",
-      "examples": ["center", "space-between"],
-      "category": "Flexbox"
-    },
-    {
-      "name": "flex",
-      "type": "shorthand",
-      "longhands": ["flex-grow", "flex-shrink", "flex-basis"],
-      "default": "0 1 auto",
-      "doc": "Shorthand zur Steuerung der Flex-Item-Größe.",
-      "category": "Flexbox"
-    }
-  ],
-  "grid": [
-    {
-      "name": "grid-template-columns",
-      "type": "grid-track",
-      "values": ["auto", "minmax()", "repeat()", "1fr"],
-      "default": "none",
-      "doc": "Definiert Spaltenstruktur; nutzt Helfer wie repeat und minmax.",
-      "examples": ["repeat(2, 1fr)", "minmax(150px, 1fr)"],
-      "category": "Grid"
-    },
-    {
-      "name": "gap",
-      "type": "length",
-      "units": ["px", "rem", "%"],
-      "range": { "min": 0, "max": 64, "step": 4 },
-      "default": "0px",
-      "doc": "Abstand zwischen Grid-/Flex-Zellen.",
-      "category": "Grid"
-    }
-  ]
-}
-      </pre>
-    </section>
-
-    <section id="state-diagram">
-      <h2>9. State-Diagramm &amp; Event-Flow</h2>
-      <div class="grid cols-2">
-        <div>
-          <h3>State-Diagramm (vereinfacht)</h3>
-          <pre>
-┌──────────────┐   User Input   ┌──────────────┐
-│ UIControls   │ ─────────────▶ │ StateStore   │
-└──────┬───────┘                └──────┬───────┘
-       │                              │
-       │ Render Updates               │ Notify
-       ▼                              ▼
-┌──────────────┐   Generate CSS  ┌──────────────┐
-│ Preview      │ ◀────────────── │ CodeGen      │
-└──────┬───────┘                 └──────┬───────┘
-       │ Inspector Feedback            │ History
-       ▼                               ▼
-┌──────────────┐                 ┌──────────────┐
-│ Inspector    │◀───────────────▶│ Undo/Redo    │
-└──────────────┘                 └──────────────┘
-          </pre>
-        </div>
-        <div>
-          <h3>Event-Flow (Schritte)</h3>
-          <ol>
-            <li>Nutzer:in ändert Control → UIControls validiert Input (PropertyModel).</li>
-            <li>StateStore aktualisiert Zustand, schreibt History-Eintrag.</li>
-            <li>CodeGen erzeugt differenzielles CSS (gewählte Output-Variante).</li>
-            <li>PreviewSandbox injiziert Styles, Inspector misst Wirkung.</li>
-            <li>Inspector liefert Konflikt-/Hinweis-Events zurück (Overlay, Toast).</li>
-            <li>Toolbar &amp; Sidebar aktualisieren „geänderte Eigenschaften“ &amp; Preset-Status.</li>
-          </ol>
-        </div>
-      </div>
-    </section>
-
-    <section id="components">
-      <h2>10. Komponentenliste</h2>
-      <table>
-        <thead>
-          <tr>
-            <th>Komponente</th>
-            <th>Props / Daten</th>
-            <th>Events</th>
-            <th>Beschreibung</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>SidebarTree</td>
-            <td>categories, filterMode, searchQuery</td>
-            <td>onSelectCategory, onSearch, onToggleFilter</td>
-            <td>Kategorienavigation, Suche &amp; Filterchips.</td>
-          </tr>
-          <tr>
-            <td>Toolbar</td>
-            <td>theme, undoAvailable, redoAvailable, presets</td>
-            <td>onReset, onUndo, onRedo, onToggleTheme, onSelectPreset, onExport</td>
-            <td>Globale Steuerung &amp; Shortcuts.</td>
-          </tr>
-          <tr>
-            <td>PropertyPanel</td>
-            <td>selectedProperties, locale, showOnlyChanged</td>
-            <td>onPropertyChange, onUnitChange, onToggleAdvanced</td>
-            <td>Generiert Controls &amp; Didaktik-Bausteine.</td>
-          </tr>
-          <tr>
-            <td>CodePanel</td>
-            <td>cssText, mode (inline|scoped|global), changedOnly</td>
-            <td>onCopyCode, onModeChange, onToggleChangedOnly</td>
-            <td>Zeigt und exportiert CSS.</td>
-          </tr>
-          <tr>
-            <td>PreviewTabs</td>
-            <td>scenarios, activeScenario, beforeAfterEnabled</td>
-            <td>onSelectScenario, onToggleBeforeAfter, onInspectNode</td>
-            <td>Sandbox mit Tabs &amp; Split View.</td>
-          </tr>
-          <tr>
-            <td>InspectorOverlay</td>
-            <td>activeNode, computedStyles, specificityInfo</td>
-            <td>onHighlightNode, onShowConflicts</td>
-            <td>Visualisiert Änderungen &amp; Konflikte.</td>
-          </tr>
-          <tr>
-            <td>PresetManager</td>
-            <td>presetList, userPresets</td>
-            <td>onApplyPreset, onSavePreset, onDeletePreset</td>
-            <td>Verwaltet vordefinierte &amp; eigene Presets.</td>
-          </tr>
-          <tr>
-            <td>IntlSwitcher</td>
-            <td>locales, activeLocale</td>
-            <td>onChangeLocale</td>
-            <td>Sprachumschalter (de/en).</td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
-
-    <section id="didactics">
-      <h2>11. Didaktische Hinweise je Kategorie</h2>
-      <div class="grid cols-2">
-        <div>
-          <h3>Layout</h3>
-          <ul>
-            <li>Merksatz: Layout-Properties wirken oft nur bei passenden Display-Typen.</li>
-            <li>Übung: Positioniere ein Badge absolut und setze <code>position: relative</code> am Container.</li>
-            <li>Warnung: <code>z-index</code> benötigt Stacking Context (z. B. Positionierung).</li>
-          </ul>
-          <h3>Flexbox</h3>
-          <ul>
-            <li>Merksatz: „Flex-Kinder hören nur, wenn Eltern flexen.“</li>
-            <li>Übung: Erzeuge zentriertes Layout (Preset Flex-Center).</li>
-            <li>Hinweis: <code>flex-basis</code> überschreibt <code>width</code>.</li>
-          </ul>
-          <h3>Grid</h3>
-          <ul>
-            <li>Merksatz: Tracks zuerst planen, dann Areas benennen.</li>
-            <li>Übung: Baue 2-Spalten-Grid mit <code>repeat</code> &amp; <code>minmax</code>.</li>
-            <li>Warnung: <code>justify-content</code> vs. <code>justify-items</code> unterscheiden.</li>
-          </ul>
-          <h3>Typografie</h3>
-          <ul>
-            <li>Merksatz: <code>line-height</code> ohne Einheit bevorzugen (Skalierung).</li>
-            <li>Übung: Stelle responsive Typo mit <code>clamp()</code> ein.</li>
-            <li>Warnung: <code>font-size</code> beeinflusst Rem-basierte Abstände.</li>
-          </ul>
-        </div>
-        <div>
-          <h3>Farbe &amp; Hintergrund</h3>
-          <ul>
-            <li>Merksatz: Mehrere Background-Layer werden von oben nach unten gerendert.</li>
-            <li>Übung: Kombiniere Verlauf + Bild mit <code>background-blend-mode</code> <span class="badge pro">Pro</span>.</li>
-            <li>Warnung: Transparente Farben beeinflussen Kontrast (A11y-Check).</li>
-          </ul>
-          <h3>Dekoration &amp; Effekte</h3>
-          <ul>
-            <li>Merksatz: Shadows nutzen rgba für weiche Kanten.</li>
-            <li>Übung: Card-Schatten-Preset anwenden &amp; variieren.</li>
-            <li>Warnung: Viele Filter können Performance kosten.</li>
-          </ul>
-          <h3>Responsive &amp; Logik</h3>
-          <ul>
-            <li>Merksatz: Mobile First – min-width Media Queries bevorzugen.</li>
-            <li>Übung: Container Query aktivieren und Komponenten innerhalb testen.</li>
-            <li>Warnung: @supports fallback definieren (z. B. <code>display: block</code>).</li>
-          </ul>
-          <h3>Kaskade &amp; Layer</h3>
-          <ul>
-            <li>Merksatz: Spezifität gewinnt, bei Gleichstand entscheidet Source Order.</li>
-            <li>Übung: Layer-Hierarchie visualisieren &amp; Prioritäten ändern.</li>
-            <li>Warnung: <code>!important</code> sparsam einsetzen, Inspector zeigt Alternativen.</li>
-          </ul>
-        </div>
-      </div>
-    </section>
-
-    <section id="mvp">
-      <h2>12. MVP-Scope vs. Erweiterungen</h2>
-      <div class="grid cols-2">
-        <div>
-          <h3>MVP (Basis)</h3>
-          <ul>
-            <li>Sidebar mit Kategorien, Suche, Filter „Basics“.</li>
-            <li>Property-Panel mit Kern-Properties jeder Kategorie.</li>
-            <li>Code-Panel (Inline/Scoped/Global) &amp; Copy-Button.</li>
-            <li>Live-Vorschau (Text, Card, Grid), Undo/Redo, Reset.</li>
-            <li>Preset-Auswahl (Flex-Center, 2-Spalten-Grid, Card-Schatten).</li>
-            <li>LocalStorage: letzte Session speichern.</li>
-            <li>Inspector mit Highlight &amp; Konflikt-Hinweisen (Basis).</li>
-          </ul>
-        </div>
-        <div>
-          <h3>Erweiterungen <span class="badge pro">Pro</span></h3>
-          <ul>
-            <li>Before/After-Split View &amp; Visual Diff.</li>
-            <li>Specificity-Graph &amp; Cascade-Layer-Editor.</li>
-            <li>Container-Query Playground mit multiplen Containern.</li>
-            <li>Animation Timeline &amp; Scroll-Linked Animations.</li>
-            <li>Export als Zip (HTML, CSS, JSON Presets).</li>
-            <li>Team-Sharing via URL-Hash / JSON Export.</li>
-            <li>Guided Challenges &amp; Schritt-für-Schritt-Lösungen.</li>
-          </ul>
-        </div>
-      </div>
-    </section>
-
-    <section id="edge-cases">
-      <h2>13. Edge-Cases &amp; Lernfallen</h2>
-      <ul>
-        <li>Shorthands vs. Longhands: UI warnt vor Überschreibung (z. B. <code>margin</code> setzt Einzelwerte zurück).</li>
-        <li>Unwirksame Werte: Tooltip erklärt „line-height: normal“ vs. numerischer Wert.</li>
-        <li>Stacking Context: Visual Layer zeigt neue Kontexte (transform, opacity &lt; 1).</li>
-        <li>Containment &amp; Container Queries: Zwei Container mit gleichem Component-Template zum Vergleich.</li>
-        <li>Fallbacks: Mehrere <code>@font-face</code>-Quellen, Background-Layer, Font-Stacks.</li>
-        <li>Cross-Property-Konflikte (z. B. <code>overflow:hidden</code> + Schatten) mit Warnhinweis.</li>
-      </ul>
-    </section>
-
-    <section id="presets">
-      <h2>14. Testfälle &amp; Presets</h2>
-      <ul>
-        <li><strong>Flex-Center:</strong> <code>display:flex; justify-content:center; align-items:center;</code></li>
-        <li><strong>2-Spalten-Grid:</strong> <code>grid-template-columns: repeat(2, 1fr); gap: 1rem;</code></li>
-        <li><strong>Responsive Typo:</strong> <code>font-size: clamp(1rem, 2vw + 0.5rem, 1.5rem);</code></li>
-        <li><strong>Card-Schatten:</strong> <code>border-radius: 12px; box-shadow: 0 8px 24px rgba(0,0,0,.15);</code></li>
-        <li><strong>Overlay-Badge:</strong> <code>position:absolute; inset:auto 8px 8px auto;</code></li>
-        <li><strong>Hero Gradient <span class="badge pro">Pro</span>:</strong> Layered background mit radial &amp; linear gradient.</li>
-        <li><strong>Table Zebra:</strong> <code>:nth-child(even)</code> &amp; <code>background-color</code>.</li>
-        <li><strong>Animation Pulse:</strong> <code>@keyframes</code> + <code>animation-iteration-count: infinite;</code></li>
-      </ul>
-    </section>
-
-    <section id="output">
-      <h2>15. Output-Erwartung</h2>
-      <ul>
-        <li>Umsetzbares Dashboard (Single-File optional) mit oben definierten Modulen.</li>
-        <li>Sitemaps &amp; Wireframes (siehe Abschnitt 4).</li>
-        <li>Komponentenliste mit Props/Events (Abschnitt 10).</li>
-        <li>Property-Schema Beispiele (Abschnitt 8).</li>
-        <li>State-Diagramm &amp; Event-Flow (Abschnitt 9).</li>
-        <li>Didaktische Hinweise (Abschnitt 11).</li>
-        <li>MVP &amp; Erweiterungen (Abschnitt 12).</li>
-      </ul>
-    </section>
-
-    <section id="acceptance">
-      <h2>16. Akzeptanzkriterien</h2>
-      <ol class="checklist">
-        <li>Alle Kategorien inkl. Properties &amp; Direktiven abgedeckt, Pro-Themen markiert.</li>
-        <li>Navigation: Sidebar + Toolbar + 3-Spalten-Hauptbereich konzeptionell beschrieben.</li>
-        <li>Live-Vorschau beschreibt Sandbox, Overlays, Konflikt-Hinweise &amp; Before/After.</li>
-        <li>Interaktion: Regler, Dropdowns, Farbwahl, Shortcuts, Snapping dokumentiert.</li>
-        <li>Technische Architektur: Module, Performance, A11y, i18n.</li>
-        <li>Datenmodell: JSON-Beispiele für mind. drei Kategorien.</li>
-        <li>State-Diagramm &amp; Event-Flow vorhanden.</li>
-        <li>Komponentenliste inkl. Props &amp; Events erstellt.</li>
-        <li>Didaktik: pro Kategorie Hinweise &amp; Übungen.</li>
-        <li>MVP vs. Pro-Features klar getrennt.</li>
-        <li>Edge-Cases, Presets/Testfälle aufgeführt.</li>
-        <li>Single-File-Umsetzung möglich (keine externen Abhängigkeiten erforderlich).</li>
-      </ol>
-    </section>
-  </main>
-</body>
+      </main>
+    </div>
+    <script type="module" src="src/main.js"></script>
+  </body>
 </html>

--- a/src/controls.js
+++ b/src/controls.js
@@ -1,0 +1,101 @@
+import { store } from "./state.js";
+
+function formatValue(value, unit) {
+  if (unit === "rem") {
+    return `${parseFloat(value).toFixed(2)} rem`;
+  }
+  if (unit === "px") {
+    return `${parseFloat(value)} px`;
+  }
+  return value;
+}
+
+function normaliseValue(input) {
+  const property = input.dataset.property;
+  let value = input.type === "checkbox" ? input.checked : input.value;
+
+  if (input.type === "range") {
+    const unit = input.dataset.unit;
+    value = `${input.value}${unit ?? ""}`;
+  } else if (input.type === "color") {
+    value = input.value;
+  } else if (input.type === "checkbox") {
+    value = input.checked ? input.dataset.on : input.dataset.off;
+  } else if (property === "line-height") {
+    value = parseFloat(input.value).toString();
+  }
+
+  return value;
+}
+
+function setControlValue(input, value) {
+  if (input.type === "checkbox") {
+    const checkedValue = input.dataset.on;
+    input.checked = value === checkedValue;
+  } else if (input.type === "color") {
+    input.value = value || "#000000";
+  } else if (input.type === "range") {
+    const unit = input.dataset.unit ?? "";
+    let numeric = value;
+    if (typeof value === "string" && unit && value.endsWith(unit)) {
+      numeric = value.slice(0, value.length - unit.length);
+    }
+    const parsed = Number.parseFloat(numeric);
+    input.value = Number.isNaN(parsed) ? input.min : parsed;
+  } else {
+    input.value = value;
+  }
+}
+
+function updateOutputs(form, state) {
+  const controls = form.querySelectorAll("[data-property]");
+  controls.forEach((input) => {
+    const property = input.dataset.property;
+    const currentValue = state.properties[property] ?? "";
+    setControlValue(input, currentValue);
+
+    const output = form.querySelector(`[data-output-for="${input.id}"]`);
+    if (output) {
+      let displayValue = currentValue;
+      if (input.type === "range") {
+        const unit = input.dataset.unit ?? "";
+        const numeric = currentValue.endsWith(unit)
+          ? currentValue.slice(0, currentValue.length - unit.length)
+          : currentValue;
+        displayValue = formatValue(numeric, unit);
+      }
+      if (input.type === "color") {
+        displayValue = currentValue;
+      }
+      output.textContent = displayValue;
+    }
+  });
+}
+
+export function initControls() {
+  const form = document.querySelector("[data-controls]");
+  if (!form) return;
+
+  const update = (state) => updateOutputs(form, state);
+  const unsubscribe = store.subscribe(update);
+
+  const handleEvent = (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement || target instanceof HTMLSelectElement)) {
+      return;
+    }
+    const property = target.dataset.property;
+    if (!property) return;
+    const value = normaliseValue(target);
+    store.updateProperty(property, value);
+  };
+
+  form.addEventListener("input", handleEvent);
+  form.addEventListener("change", handleEvent);
+
+  return () => {
+    unsubscribe();
+    form.removeEventListener("input", handleEvent);
+    form.removeEventListener("change", handleEvent);
+  };
+}

--- a/src/export.js
+++ b/src/export.js
@@ -1,0 +1,64 @@
+import { store } from "./state.js";
+
+function buildInlineCode(selector, properties, modified) {
+  if (Object.keys(modified).length === 0) {
+    return `<!-- Keine Änderungen gegenüber dem Preset für ${selector} -->`;
+  }
+  const declarations = Object.entries(modified)
+    .map(([property, value]) => `${property}: ${value};`)
+    .join(" ");
+  const primarySelector = selector.split(",")[0].trim();
+  const className = primarySelector.startsWith(".")
+    ? primarySelector.slice(1)
+    : primarySelector.replace(/[^a-z0-9_-]/gi, "-");
+  return `<div class="${className}" style="${declarations}">…</div>`;
+}
+
+function buildScopedCode(selector, properties, modified) {
+  if (Object.keys(modified).length === 0) {
+    return `/* Keine Differenzen zum aktuellen Preset */`;
+  }
+  const lines = Object.entries(modified)
+    .map(([property, value]) => `  ${property}: ${value};`)
+    .join("\n");
+  return `.preview-sandbox ${selector} {\n${lines}\n}`;
+}
+
+function buildGlobalCode(selector, properties, modified) {
+  if (Object.keys(modified).length === 0) {
+    return `/* Verwende das Preset unverändert */`;
+  }
+  const lines = Object.entries(modified)
+    .map(([property, value]) => `  ${property}: ${value};`)
+    .join("\n");
+  return `${selector} {\n${lines}\n}`;
+}
+
+function buildCode(mode, selector, properties, modified) {
+  switch (mode) {
+    case "inline":
+      return buildInlineCode(selector, properties, modified);
+    case "scoped":
+      return buildScopedCode(selector, properties, modified);
+    case "global":
+    default:
+      return buildGlobalCode(selector, properties, modified);
+  }
+}
+
+export function initExportPanel() {
+  const select = document.getElementById("export-mode");
+  const codeBlock = document.querySelector("[data-code-output]");
+  if (!select || !codeBlock) return;
+
+  const render = (state) => {
+    const modified = store.getModifiedProperties();
+    const mode = select.value;
+    const code = buildCode(mode, state.selector, state.properties, modified);
+    codeBlock.textContent = code;
+    codeBlock.classList.toggle("code-output__placeholder", Object.keys(modified).length === 0);
+  };
+
+  select.addEventListener("change", () => render(store.getState()));
+  store.subscribe(render);
+}

--- a/src/inspector.js
+++ b/src/inspector.js
@@ -1,0 +1,165 @@
+import { store } from "./state.js";
+
+function calculateSpecificity(selector) {
+  let a = 0;
+  let b = 0;
+  let c = 0;
+
+  const tokens = selector.split(/\s+/);
+  tokens.forEach((token) => {
+    const cleaned = token.replace(/[,:+>~]/g, " ").trim();
+    if (!cleaned) return;
+    cleaned.split(/(?=\.)|(?=#)|\s+/).forEach((part) => {
+      if (!part) return;
+      if (part.startsWith("#")) {
+        a += 1;
+      } else if (part.startsWith(".")) {
+        b += 1;
+      } else if (part.includes("[")) {
+        b += 1;
+      } else {
+        c += 1;
+      }
+    });
+  });
+
+  return { a, b, c, score: `${a},${b},${c}` };
+}
+
+function createRuleMarkup(selector, properties) {
+  const specificity = calculateSpecificity(selector);
+  const lines = Object.entries(properties)
+    .map(([property, value]) => `  ${property}: ${value};`)
+    .join("\n");
+
+  return {
+    specificity,
+    markup: `${selector} {\n${lines}\n}`,
+  };
+}
+
+function collectWarnings(state, modified) {
+  const warnings = [];
+  const display = state.properties.display;
+
+  const usesFlexProps = ["justify-content", "align-items", "flex-direction"].some(
+    (prop) => modified[prop]
+  );
+  if (usesFlexProps && display !== "flex") {
+    warnings.push({
+      title: "Flex Eigenschaften aktiv",
+      description:
+        "Aktiviere \"display: flex\", um Flex-Ausrichtungen wirksam werden zu lassen.",
+    });
+  }
+
+  if (modified["grid-template-columns"] && display !== "grid") {
+    warnings.push({
+      title: "Grid Template ohne Grid",
+      description: "Setze \"display: grid\", damit das Spaltenlayout aktiv ist.",
+    });
+  }
+
+  if (modified.gap && display === "block") {
+    warnings.push({
+      title: "Gap ohne Layout-Kontext",
+      description: "Gap entfaltet Wirkung nur innerhalb von Flex- oder Grid-Layouts.",
+    });
+  }
+
+  if (modified["border-width"] && !modified["border-color"]) {
+    warnings.push({
+      title: "Border ohne Farbe",
+      description: "Definiere eine Border-Farbe, um die Kontur sichtbar zu machen.",
+    });
+  }
+
+  return warnings;
+}
+
+function renderRules(list, state, modified) {
+  list.innerHTML = "";
+  if (Object.keys(modified).length === 0) {
+    const empty = document.createElement("li");
+    empty.textContent = "Keine Abweichungen vom Preset.";
+    list.appendChild(empty);
+    return;
+  }
+
+  const { markup, specificity } = createRuleMarkup(state.selector, modified);
+  const item = document.createElement("li");
+  item.className = "rule";
+  const selectorEl = document.createElement("div");
+  selectorEl.className = "rule__selector";
+  selectorEl.textContent = state.selector;
+  const specificityEl = document.createElement("div");
+  specificityEl.className = "rule__specificity";
+  specificityEl.textContent = `Specificity: ${specificity.score}`;
+  const codeEl = document.createElement("pre");
+  codeEl.textContent = markup;
+  item.append(selectorEl, specificityEl, codeEl);
+  list.appendChild(item);
+}
+
+function renderDiff(tableBody, state, modified) {
+  tableBody.innerHTML = "";
+  if (Object.keys(modified).length === 0) {
+    const row = document.createElement("tr");
+    const cell = document.createElement("td");
+    cell.colSpan = 3;
+    cell.textContent = "Noch keine Änderungen.";
+    row.appendChild(cell);
+    tableBody.appendChild(row);
+    return;
+  }
+
+  Object.entries(modified).forEach(([property, value]) => {
+    const row = document.createElement("tr");
+    const name = document.createElement("th");
+    name.scope = "row";
+    name.textContent = property;
+    const before = document.createElement("td");
+    before.textContent = state.baseline[property] ?? "—";
+    const after = document.createElement("td");
+    after.textContent = value;
+    row.append(name, before, after);
+    tableBody.appendChild(row);
+  });
+}
+
+function renderWarnings(list, state, modified) {
+  list.innerHTML = "";
+  const warnings = collectWarnings(state, modified);
+  if (warnings.length === 0) {
+    const item = document.createElement("li");
+    item.textContent = "Keine Probleme erkannt.";
+    list.appendChild(item);
+    return;
+  }
+
+  warnings.forEach((warning) => {
+    const item = document.createElement("li");
+    item.className = "warning";
+    const title = document.createElement("span");
+    title.className = "warning__title";
+    title.textContent = warning.title;
+    const description = document.createElement("span");
+    description.textContent = warning.description;
+    item.append(title, description);
+    list.appendChild(item);
+  });
+}
+
+export function initInspector() {
+  const ruleList = document.querySelector("[data-rule-list]");
+  const diffBody = document.querySelector("[data-diff-body]");
+  const warningList = document.querySelector("[data-warning-list]");
+  if (!ruleList || !diffBody || !warningList) return;
+
+  store.subscribe((state) => {
+    const modified = store.getModifiedProperties();
+    renderRules(ruleList, state, modified);
+    renderDiff(diffBody, state, modified);
+    renderWarnings(warningList, state, modified);
+  });
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,79 @@
+import { initControls } from "./controls.js";
+import { initPreview } from "./preview.js";
+import { initInspector } from "./inspector.js";
+import { initExportPanel } from "./export.js";
+import { store } from "./state.js";
+import { presets } from "./presets.js";
+
+function populatePresets(select) {
+  if (select.dataset.populated === "true") {
+    return;
+  }
+  presets.forEach((preset) => {
+    const option = document.createElement("option");
+    option.value = preset.id;
+    option.textContent = preset.label;
+    select.appendChild(option);
+  });
+  const customOption = document.createElement("option");
+  customOption.value = "custom";
+  customOption.textContent = "Benutzerdefiniert";
+  select.appendChild(customOption);
+  select.dataset.populated = "true";
+}
+
+function initToolbar() {
+  const presetSelect = document.getElementById("preset-select");
+  const undoButton = document.getElementById("undo-button");
+  const redoButton = document.getElementById("redo-button");
+  const resetButton = document.getElementById("reset-button");
+  if (!presetSelect || !undoButton || !redoButton || !resetButton) return;
+
+  populatePresets(presetSelect);
+
+  presetSelect.addEventListener("change", (event) => {
+    const value = event.target.value;
+    if (value === "custom") {
+      return;
+    }
+    store.applyPreset(value);
+  });
+
+  undoButton.addEventListener("click", () => store.undo());
+  redoButton.addEventListener("click", () => store.redo());
+  resetButton.addEventListener("click", () => store.resetToBaseline());
+
+  store.subscribe((state) => {
+    if (state.activePreset === "custom" && !presetSelect.querySelector('option[value="custom"]')) {
+      populatePresets(presetSelect);
+    }
+    presetSelect.value = state.activePreset;
+    undoButton.disabled = !state.canUndo;
+    redoButton.disabled = !state.canRedo;
+  });
+}
+
+function initKeyboardShortcuts() {
+  document.addEventListener("keydown", (event) => {
+    const key = event.key.toLowerCase();
+    const isUndo = (event.metaKey || event.ctrlKey) && !event.shiftKey && key === "z";
+    const isRedo =
+      (event.metaKey || event.ctrlKey) && ((event.shiftKey && key === "z") || key === "y");
+    if (isUndo) {
+      event.preventDefault();
+      store.undo();
+    } else if (isRedo) {
+      event.preventDefault();
+      store.redo();
+    }
+  });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  initToolbar();
+  initControls();
+  initPreview();
+  initInspector();
+  initExportPanel();
+  initKeyboardShortcuts();
+});

--- a/src/presets.js
+++ b/src/presets.js
@@ -1,0 +1,75 @@
+export const presets = [
+  {
+    id: "starter",
+    label: "Starter Card",
+    description: "Grundlayout für Kartenkomponenten.",
+    properties: {
+      display: "flex",
+      "flex-direction": "column",
+      "justify-content": "flex-start",
+      "align-items": "stretch",
+      gap: "1rem",
+      padding: "1.5rem",
+      "grid-template-columns": "",
+      "box-shadow": "0 24px 48px rgba(15, 23, 42, 0.16)",
+      "font-size": "1.05rem",
+      "font-weight": "500",
+      "line-height": "1.5",
+      "background-color": "#ffffff",
+      color: "#111827",
+      "border-radius": "1.25rem",
+      "border-width": "0px",
+      "border-color": "#e2e8f0"
+    }
+  },
+  {
+    id: "hero",
+    label: "Hero Banner",
+    description: "Breites Layout mit großzügiger Typografie.",
+    properties: {
+      display: "flex",
+      "flex-direction": "row",
+      "justify-content": "space-between",
+      "align-items": "center",
+      gap: "1.5rem",
+      padding: "2.5rem",
+      "grid-template-columns": "",
+      "box-shadow": "none",
+      "font-size": "1.35rem",
+      "font-weight": "600",
+      "line-height": "1.35",
+      "background-color": "#0f172a",
+      color: "#f8fafc",
+      "border-radius": "1.5rem",
+      "border-width": "0px",
+      "border-color": "#1f2937"
+    }
+  },
+  {
+    id: "feature-grid",
+    label: "Feature Grid",
+    description: "Grid-Basierte Darstellung mehrerer Kacheln.",
+    properties: {
+      display: "grid",
+      "flex-direction": "column",
+      "justify-content": "flex-start",
+      "align-items": "stretch",
+      gap: "1.5rem",
+      padding: "2rem",
+      "grid-template-columns": "repeat(auto-fit, minmax(160px, 1fr))",
+      "box-shadow": "0 12px 32px rgba(30, 64, 175, 0.2)",
+      "font-size": "1rem",
+      "font-weight": "500",
+      "line-height": "1.45",
+      "background-color": "#f8fafc",
+      color: "#0f172a",
+      "border-radius": "1rem",
+      "border-width": "1px",
+      "border-color": "#93c5fd"
+    }
+  }
+];
+
+export function getPresetById(id) {
+  return presets.find((preset) => preset.id === id);
+}

--- a/src/preview.js
+++ b/src/preview.js
@@ -1,0 +1,113 @@
+import { store } from "./state.js";
+
+const PREVIEW_DOCUMENT = `<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: linear-gradient(140deg, #e0f2fe, #eef2ff);
+        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        display: grid;
+        place-items: center;
+        padding: 2rem;
+      }
+      .preview-card {
+        max-width: 480px;
+        width: 100%;
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        padding: 1.5rem;
+        border-radius: 1.25rem;
+        background: #ffffff;
+        color: #111827;
+        border: 0;
+      }
+      .preview-card h2 {
+        margin: 0;
+        font-size: clamp(1.4rem, 3vw, 1.75rem);
+      }
+      .preview-card p {
+        margin: 0;
+        color: rgba(15, 23, 42, 0.75);
+      }
+      .preview-card .actions {
+        display: flex;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+      .preview-card button {
+        border: none;
+        border-radius: 999px;
+        padding: 0.65rem 1.4rem;
+        font: inherit;
+        cursor: pointer;
+      }
+      .preview-card button.primary {
+        background: linear-gradient(120deg, #4f46e5, #6366f1);
+        color: #ffffff;
+        box-shadow: 0 14px 32px rgba(99, 102, 241, 0.35);
+      }
+      .preview-card button.secondary {
+        background: rgba(99, 102, 241, 0.1);
+        color: #3730a3;
+      }
+    </style>
+  </head>
+  <body>
+    <article class="preview-card">
+      <h2>Produktivität im Fokus</h2>
+      <p>Gestalte modulare Komponenten und teste CSS-Kombinationen in Echtzeit.</p>
+      <div class="actions">
+        <button class="primary">Jetzt starten</button>
+        <button class="secondary">Dokumentation</button>
+      </div>
+    </article>
+  </body>
+</html>`;
+
+function applyStyles(doc, styles) {
+  const element = doc.querySelector(".preview-card");
+  if (!element) return;
+  element.style.cssText = "";
+  Object.entries(styles).forEach(([property, value]) => {
+    if (value === undefined || value === null || value === "") {
+      element.style.removeProperty(property);
+    } else {
+      element.style.setProperty(property, value);
+    }
+  });
+
+  if (styles["border-width"] && styles["border-width"] !== "0px") {
+    element.style.setProperty("border-style", "solid");
+  } else {
+    element.style.removeProperty("border-style");
+  }
+}
+
+export function initPreview() {
+  const iframe = document.getElementById("preview-frame");
+  if (!iframe) return;
+
+  iframe.srcdoc = PREVIEW_DOCUMENT;
+
+  const render = (state) => {
+    const doc = iframe.contentDocument;
+    if (!doc) return;
+    applyStyles(doc, state.properties);
+  };
+
+  iframe.addEventListener("load", () => {
+    render(store.getState());
+  });
+
+  store.subscribe(render);
+}

--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,142 @@
+import { presets, getPresetById } from "./presets.js";
+
+const DEFAULT_PRESET_ID = presets[0]?.id ?? "starter";
+
+function clone(object) {
+  return JSON.parse(JSON.stringify(object));
+}
+
+class Store {
+  constructor(initialPresetId = DEFAULT_PRESET_ID) {
+    const preset = getPresetById(initialPresetId) ?? presets[0];
+    const baseline = clone(preset.properties);
+
+    this.state = {
+      selector: ".preview-card",
+      properties: clone(preset.properties),
+      baseline,
+      baselinePresetId: preset.id,
+      activePreset: preset.id,
+    };
+
+    this.listeners = new Set();
+    this.history = [clone(this.state.properties)];
+    this.pointer = 0;
+  }
+
+  recalculateActivePresetTag() {
+    const modified = this.getModifiedProperties();
+    if (Object.keys(modified).length === 0) {
+      this.state.activePreset = this.state.baselinePresetId;
+    } else {
+      this.state.activePreset = "custom";
+    }
+  }
+
+  subscribe(listener) {
+    this.listeners.add(listener);
+    listener(this.getState());
+    return () => this.listeners.delete(listener);
+  }
+
+  notify() {
+    const snapshot = this.getState();
+    this.listeners.forEach((listener) => listener(snapshot));
+  }
+
+  getState() {
+    return {
+      selector: this.state.selector,
+      properties: clone(this.state.properties),
+      baseline: clone(this.state.baseline),
+      baselinePresetId: this.state.baselinePresetId,
+      activePreset: this.state.activePreset,
+      canUndo: this.canUndo(),
+      canRedo: this.canRedo(),
+    };
+  }
+
+  canUndo() {
+    return this.pointer > 0;
+  }
+
+  canRedo() {
+    return this.pointer < this.history.length - 1;
+  }
+
+  commit(newProperties, { replaceHistory = false } = {}) {
+    if (replaceHistory) {
+      this.history = [clone(newProperties)];
+      this.pointer = 0;
+    } else {
+      const serialized = JSON.stringify(newProperties);
+      const currentSerialized = JSON.stringify(this.history[this.pointer]);
+      if (serialized === currentSerialized) {
+        return;
+      }
+      this.history = this.history.slice(0, this.pointer + 1);
+      this.history.push(clone(newProperties));
+      this.pointer = this.history.length - 1;
+    }
+    this.notify();
+  }
+
+  updateProperty(property, value) {
+    if (!(property in this.state.properties)) {
+      this.state.properties[property] = value;
+    } else if (this.state.properties[property] === value) {
+      return;
+    } else {
+      this.state.properties[property] = value;
+    }
+
+    this.recalculateActivePresetTag();
+
+    this.commit(this.state.properties);
+  }
+
+  applyPreset(presetId) {
+    const preset = getPresetById(presetId);
+    if (!preset) return;
+    this.state.baseline = clone(preset.properties);
+    this.state.properties = clone(preset.properties);
+    this.state.baselinePresetId = preset.id;
+    this.state.activePreset = preset.id;
+    this.commit(this.state.properties, { replaceHistory: true });
+  }
+
+  resetToBaseline() {
+    this.state.properties = clone(this.state.baseline);
+    this.state.activePreset = this.state.baselinePresetId;
+    this.commit(this.state.properties, { replaceHistory: true });
+  }
+
+  undo() {
+    if (!this.canUndo()) return;
+    this.pointer -= 1;
+    this.state.properties = clone(this.history[this.pointer]);
+    this.recalculateActivePresetTag();
+    this.notify();
+  }
+
+  redo() {
+    if (!this.canRedo()) return;
+    this.pointer += 1;
+    this.state.properties = clone(this.history[this.pointer]);
+    this.recalculateActivePresetTag();
+    this.notify();
+  }
+
+  getModifiedProperties() {
+    const modified = {};
+    for (const [property, value] of Object.entries(this.state.properties)) {
+      const baselineValue = this.state.baseline[property] ?? "";
+      if (value !== baselineValue) {
+        modified[property] = value;
+      }
+    }
+    return modified;
+  }
+}
+
+export const store = new Store(DEFAULT_PRESET_ID);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,422 @@
+:root {
+  color-scheme: light;
+  --bg-canvas: #f5f7fb;
+  --bg-surface: #ffffff;
+  --bg-sidebar: #101323;
+  --text-primary: #12142b;
+  --text-secondary: #4c516d;
+  --accent: #4c6fff;
+  --accent-soft: rgba(76, 111, 255, 0.1);
+  --border-subtle: #d9dff1;
+  --border-strong: #b9c2dc;
+  --shadow-soft: 0 24px 48px rgba(16, 19, 35, 0.12);
+  --radius-lg: 18px;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg-canvas);
+  color: var(--text-primary);
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  background: linear-gradient(135deg, rgba(76, 111, 255, 0.08), rgba(255, 255, 255, 0));
+}
+
+.sidebar {
+  background: var(--bg-sidebar);
+  color: #f4f6ff;
+  padding: 2.5rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+  position: sticky;
+  top: 0;
+  align-self: start;
+  min-height: 100vh;
+}
+
+.brand {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.brand__title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.brand__subtitle {
+  margin: 0;
+  color: rgba(244, 246, 255, 0.68);
+  font-size: 0.9rem;
+}
+
+.nav {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.nav__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.nav__section h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(244, 246, 255, 0.6);
+}
+
+.nav__links {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.nav__links a {
+  color: inherit;
+  text-decoration: none;
+  padding: 0.55rem 0.75rem;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+}
+
+.nav__links a:hover,
+.nav__links a:focus-visible {
+  background: rgba(244, 246, 255, 0.08);
+}
+
+.workspace {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem 2.5rem 3rem;
+}
+
+.toolbar {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: 1rem 1.5rem;
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.toolbar__group {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.toolbar__group label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.toolbar select,
+.toolbar button {
+  font: inherit;
+  border-radius: 999px;
+  border: 1px solid var(--border-subtle);
+  padding: 0.45rem 1rem;
+  background: #ffffff;
+  cursor: pointer;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.toolbar button {
+  display: inline-flex;
+  gap: 0.35rem;
+  align-items: center;
+}
+
+.toolbar button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.toolbar button:not(:disabled):hover,
+.toolbar select:hover,
+.toolbar select:focus-visible,
+.toolbar button:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+  outline: none;
+}
+
+.workspace-columns {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.panel {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.panel h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+fieldset {
+  margin: 0;
+  border: none;
+  padding: 0;
+}
+
+fieldset + fieldset {
+  border-top: 1px solid var(--border-subtle);
+  padding-top: 1.25rem;
+}
+
+legend {
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-bottom: 0.75rem;
+}
+
+.form-control {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.form-control label {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.form-control input[type="range"] {
+  width: 100%;
+}
+
+.form-control input,
+.form-control select {
+  font: inherit;
+  padding: 0.45rem 0.75rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  background: #ffffff;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.form-control input:focus-visible,
+.form-control select:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+  outline: none;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.9rem;
+}
+
+.toggle input[type="checkbox"] {
+  width: 44px;
+  height: 24px;
+  -webkit-appearance: none;
+  appearance: none;
+  background: rgba(18, 20, 43, 0.25);
+  border-radius: 999px;
+  position: relative;
+  transition: background 0.2s;
+  cursor: pointer;
+}
+
+.toggle input[type="checkbox"]::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 4px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  box-shadow: 0 4px 8px rgba(16, 19, 35, 0.25);
+  transition: transform 0.2s;
+}
+
+.toggle input[type="checkbox"]:checked {
+  background: var(--accent);
+}
+
+.toggle input[type="checkbox"]:checked::after {
+  transform: translateX(18px);
+}
+
+.preview-surface {
+  border: 1px dashed var(--border-strong);
+  border-radius: calc(var(--radius-lg) - 6px);
+  background: rgba(76, 111, 255, 0.05);
+  padding: 1.5rem;
+}
+
+.preview-frame {
+  width: 100%;
+  height: 420px;
+  border: none;
+  background: #ffffff;
+  border-radius: 16px;
+  box-shadow: inset 0 0 0 1px rgba(16, 19, 35, 0.08);
+}
+
+code, pre {
+  font-family: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 0.85rem;
+}
+
+.code-output {
+  background: #0f172a;
+  color: #f8fafc;
+  border-radius: 14px;
+  padding: 1rem 1.25rem;
+  overflow-x: auto;
+  min-height: 180px;
+}
+
+.code-output__placeholder {
+  color: rgba(248, 250, 252, 0.7);
+}
+
+.warning-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.warning {
+  background: rgba(255, 190, 92, 0.15);
+  border: 1px solid rgba(255, 190, 92, 0.4);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.warning__title {
+  font-weight: 600;
+  color: #7a4a00;
+}
+
+.diff-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.diff-table th,
+.diff-table td {
+  padding: 0.45rem 0.5rem;
+  border: 1px solid rgba(18, 20, 43, 0.08);
+  text-align: left;
+}
+
+.diff-table thead {
+  background: rgba(76, 111, 255, 0.08);
+}
+
+.rules-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.rule {
+  border: 1px solid rgba(18, 20, 43, 0.08);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.rule__selector {
+  font-weight: 600;
+}
+
+.rule__specificity {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+@media (max-width: 1240px) {
+  .workspace-columns {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 960px) {
+  .app-shell {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .sidebar {
+    position: relative;
+    min-height: auto;
+    border-bottom: 1px solid rgba(244, 246, 255, 0.12);
+  }
+
+  .workspace {
+    padding: 1.5rem;
+  }
+}
+
+@media (max-width: 720px) {
+  .workspace-columns {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .toolbar__group {
+    width: 100%;
+    justify-content: space-between;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the conceptual landing copy with the dashboard scaffold including sidebar navigation, toolbar, three-column panels, and preview sandbox
- implement vanilla ES modules for shared state, interactive controls, inspector insights, code export, presets, and undo/redo behaviour that synchronises with the live preview iframe
- add responsive styling to deliver the desktop three-column layout while adapting to smaller viewports

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68de8e3c93a88324a7ec41f036a7f422